### PR TITLE
add new DPoPTokenSerializer class for [de]serializing DPoPToken

### DIFF
--- a/requests_oauth2client/__init__.py
+++ b/requests_oauth2client/__init__.py
@@ -79,6 +79,7 @@ from .discovery import (
 from .dpop import (
     DPoPKey,
     DPoPToken,
+    DPoPTokenSerializer,
     InvalidDPoPAccessToken,
     InvalidDPoPAlg,
     InvalidDPoPKey,

--- a/requests_oauth2client/authorization_request.py
+++ b/requests_oauth2client/authorization_request.py
@@ -933,6 +933,8 @@ class AuthorizationRequestSerializer:
         Serialize an AuthorizationRequest as JSON, then compress with deflate, then encodes as
         base64url.
 
+        WARNING: If the `AuthorizationRequest` has `DPoPKey`, this does not serialize custom `jti_generator`, `iat_generator` or `dpop_token_class`!
+
         Args:
             azr: the `AuthorizationRequest` to serialize
 

--- a/requests_oauth2client/tokens.py
+++ b/requests_oauth2client/tokens.py
@@ -645,7 +645,8 @@ class BearerTokenSerializer:
             BinaPy.serialize_to("json", {k: w for k, w in d.items() if w is not None}).to("deflate").to("b64u").ascii()
         )
 
-    def default_loader(self, serialized: str, token_class: type[BearerToken] = BearerToken) -> BearerToken:
+    @staticmethod
+    def default_loader(serialized: str, token_class: type[BearerToken] = BearerToken) -> BearerToken:
         """Deserialize a BearerToken.
 
         This does the opposite operations than `default_dumper`.

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -17,6 +17,8 @@ from requests_oauth2client import (
     ClientSecretBasic,
     ClientSecretJwt,
     ClientSecretPost,
+    DPoPKey,
+    DPoPToken,
     OAuth2Client,
     PrivateKeyJwt,
     PublicApp,
@@ -48,6 +50,16 @@ def access_token() -> str:
 @pytest.fixture(scope="session")
 def bearer_auth(access_token: str) -> BearerToken:
     return BearerToken(access_token)
+
+
+@pytest.fixture(scope="session")
+def dpop_key() -> DPoPKey:
+    return DPoPKey.generate()
+
+
+@pytest.fixture(scope="session")
+def dpop_token(access_token: str, dpop_key: DPoPKey) -> DPoPToken:
+    return DPoPToken(access_token=access_token, _dpop_key=dpop_key)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
for guillp/requests_oauth2client#122

@guillp one note here: this duplicates the existing code in AuthorizationRequestSerializer for [de]serializing DPoPKey. would you want a new DPoPKeySerializer class for that? I wasn't sure if you'd care more about the code duplication or the serializer class sprawl. I'm ok either way.